### PR TITLE
Add Oman agriculture site pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -3085,6 +3086,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -13932,6 +13942,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,30 @@
 .App {
-  text-align: center;
+  font-family: Arial, sans-serif;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+.nav ul {
+  list-style: none;
+  padding: 0;
+  background: #004d40;
+  margin: 0;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
 }
 
-.App-link {
-  color: #61dafb;
+.nav li {
+  margin: 0;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.nav a {
+  display: block;
+  color: #fff;
+  padding: 10px 15px;
+  text-decoration: none;
+}
+
+.nav a:hover {
+  background: #00695c;
+}
+
+.content {
+  padding: 20px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,24 +1,34 @@
-import logo from './logo.svg';
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import Home from './pages/Home';
+import Crops from './pages/Crops';
+import Livestock from './pages/Livestock';
+import Fisheries from './pages/Fisheries';
+import Modernization from './pages/Modernization';
 import './App.css';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <Router>
+      <div className="App">
+        <nav className="nav">
+          <ul>
+            <li><Link to="/">Home</Link></li>
+            <li><Link to="/crops">Crops</Link></li>
+            <li><Link to="/livestock">Livestock</Link></li>
+            <li><Link to="/fisheries">Fisheries</Link></li>
+            <li><Link to="/modernization">Modernization</Link></li>
+          </ul>
+        </nav>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/crops" element={<Crops />} />
+          <Route path="/livestock" element={<Livestock />} />
+          <Route path="/fisheries" element={<Fisheries />} />
+          <Route path="/modernization" element={<Modernization />} />
+        </Routes>
+      </div>
+    </Router>
   );
 }
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders home page heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Oman Agriculture/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/pages/Crops.js
+++ b/src/pages/Crops.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function Crops() {
+  return (
+    <div className="content">
+      <h2>Crop Farming</h2>
+      <p>
+        Date palms are the dominant crop across Oman and an important source of
+        income for many farmers. Other fruits such as limes, mangoes and
+        bananas are grown, particularly in the fertile Batinah coast and the
+        monsoon-influenced Dhofar region. Vegetable production includes
+        tomatoes, cucumbers and leafy greens, often cultivated in modern
+        greenhouses to save water.
+      </p>
+    </div>
+  );
+}

--- a/src/pages/Fisheries.js
+++ b/src/pages/Fisheries.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function Fisheries() {
+  return (
+    <div className="content">
+      <h2>Fisheries</h2>
+      <p>
+        With an extensive coastline along the Arabian Sea and the Gulf of Oman,
+        fisheries are an important sector. Artisanal fishermen land varieties of
+        tuna, sardines and other species. Oman is investing in aquaculture
+        projects to meet growing demand while ensuring sustainability of marine
+        resources.
+      </p>
+    </div>
+  );
+}

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function Home() {
+  return (
+    <div className="content">
+      <h1>Oman Agriculture</h1>
+      <p>
+        The Sultanate of Oman has diverse agricultural activities that support
+        rural communities and contribute to food security. Major farming areas
+        are located along the coastal plain of Al Batinah, interior oases and
+        in the southern Dhofar region.
+      </p>
+    </div>
+  );
+}

--- a/src/pages/Livestock.js
+++ b/src/pages/Livestock.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function Livestock() {
+  return (
+    <div className="content">
+      <h2>Livestock</h2>
+      <p>
+        Traditional herding of camels, cattle, goats and sheep remains vital for
+        many communities. Omani livestock breeds are adapted to the arid
+        climate. Government initiatives encourage improved animal husbandry and
+        veterinary services to boost production of meat and dairy products.
+      </p>
+    </div>
+  );
+}

--- a/src/pages/Modernization.js
+++ b/src/pages/Modernization.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function Modernization() {
+  return (
+    <div className="content">
+      <h2>Modernization & Sustainability</h2>
+      <p>
+        Efficient irrigation systems such as the ancient aflaj channels and
+        modern drip technology are used to conserve water. Research stations and
+        training programs help farmers adopt new practices and improve crop
+        yields. The government also supports sustainable initiatives to manage
+        scarce resources and protect the environment.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `react-router-dom`
- create informational pages about crop farming, livestock, fisheries and sustainability
- build navigation with React Router
- update tests for new content

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845e788b2ec832e8a097f7647c42e2c